### PR TITLE
Use `seqtk subseq` instead of screed for pulling reads of interest from files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
 - 3.6
-install: pip install -U tox-travis
+- 3.7
+install: pip install -U tox-travis tox-conda
 script: tox
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,16 @@ language: python
 python:
 - 3.6
 - 3.7
-install: pip install -U tox-travis tox-conda
+install:
+    - sudo apt-get update
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - source "$HOME/miniconda/etc/profile.d/conda.sh"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
+    - pip install -U tox-travis tox-conda
 script: tox
 deploy:
   provider: pypi

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.2.0 (2019-09-23)
+------------------
+
+* Use ``seqtk subseq`` instead of screed for pulling reads of interest from files
+* Added external dependencies for ``seqtk`` for pulling reads from input FASTQs and ``pbgzip`` for parallel block Gzip for output of Gzipped FASTQs
+* Removed ``screed`` Python dependency
+
+
 0.1.0 (2019-04-15)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Features
 
 * Filter for union of reads classified to taxa of interest Kraken2_ and Centrifuge_ (by default filter for Viral reads (taxid=10239))
 * Output unclassified reads along with reads from taxa of interest *or* exlude them with `--exclude-unclassified`
-* screed_ for quickly filtering reads
+* seqtk_ for quickly filtering reads and pbgzip_ for parallel block Gzip compression of output reads (recommended that these dependencies are installed with Conda_)
 
 Usage
 -----
@@ -39,8 +39,8 @@ Paired-end reads with classification results by both Kraken2_ and Centrifuge_
 
     filter_classified_reads -i /path/to/reads/R1.fq \
                             -I /path/to/reads/R2.fq \
-                            -o  /path/to/reads/R1.filtered.fq \
-                            -O  /path/to/reads/R2.filtered.fq \
+                            -o  /path/to/reads/R1.filtered.fq.gz \
+                            -O  /path/to/reads/R2.filtered.fq.gz \
                             -k  /path/to/kraken2/results.tsv \
                             -K  /path/to/kraken2/kreport.tsv \
                             -c  /path/to/centrifuge/results.tsv \
@@ -53,8 +53,8 @@ Using test data in `tests/data/`:
 
     $ filter_classified_reads -i tests/data/SRR8207674_1.viral_unclassified.seqtk_seed42_n10000.fastq.gz \
                               -I tests/data/SRR8207674_2.viral_unclassified.seqtk_seed42_n10000.fastq.gz \
-                              -o r1.fq \
-                              -O r2.fq \
+                              -o r1.fq.gz \
+                              -O r2.fq.gz \
                               -k tests/data/SRR8207674-kraken2_results.tsv \
                               -K tests/data/SRR8207674-kraken2_report.tsv \
                               -c tests/data/SRR8207674-centrifuge_results.tsv \
@@ -81,8 +81,8 @@ You should see the following log information:
     2019-04-16 13:40:34,333 INFO: Centrifuge found n=12 target reads not found with Kraken2 [in util.py:38]
     2019-04-16 13:40:34,333 INFO: Kraken2 found n=6176 target reads not found with Centrifuge [in util.py:40]
     2019-04-16 13:40:34,338 INFO: N=1701 reads unclassified by both Centrifuge and Kraken2. [in util.py:62]
-    2019-04-16 13:40:34,345 INFO: Writing n=9999 filtered reads from "tests/data/SRR8207674_1.viral_unclassified.seqtk_seed42_n10000.fastq.gz" to "r1.fq" [in cli.py:129]
-    2019-04-16 13:40:34,957 INFO: Writing n=9999 filtered reads from "tests/data/SRR8207674_2.viral_unclassified.seqtk_seed42_n10000.fastq.gz" to "r2.fq" [in cli.py:134]
+    2019-04-16 13:40:34,345 INFO: Writing n=9999 filtered reads from "tests/data/SRR8207674_1.viral_unclassified.seqtk_seed42_n10000.fastq.gz" to "r1.fq.gz" [in cli.py:129]
+    2019-04-16 13:40:34,957 INFO: Writing n=9999 filtered reads from "tests/data/SRR8207674_2.viral_unclassified.seqtk_seed42_n10000.fastq.gz" to "r2.fq.gz" [in cli.py:134]
     2019-04-16 13:40:35,459 INFO: Done! [in cli.py:137]
 
 
@@ -96,4 +96,6 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _Kraken2: https://ccb.jhu.edu/software/kraken2/
 .. _Centrifuge: https://ccb.jhu.edu/software/centrifuge/manual.shtml
-.. _screed: https://screed.readthedocs.io/en/latest/screed.html
+.. _seqtk: https://github.com/lh3/seqtk
+.. _pbgzip: https://anaconda.org/bioconda/pbgzip
+.. _Conda: https://conda.io/en/latest/

--- a/filter_classified_reads/__init__.py
+++ b/filter_classified_reads/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/filter_classified_reads/cli.py
+++ b/filter_classified_reads/cli.py
@@ -7,12 +7,11 @@ import sys
 from typing import Optional, List
 
 import click
-import screed
 
 from filter_classified_reads.util import \
     parse_taxids_string, \
     compare_kraken2_and_centrifuge
-from filter_classified_reads.io import write_reads
+from filter_classified_reads.io import write_reads_seqtk
 from filter_classified_reads.target_classified_reads import \
     TargetClassifiedReads, \
     common_unclassified_reads, \
@@ -81,10 +80,7 @@ def main(reads1: str,
             'file!')
     logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
     parsed_taxids = try_parse_taxids(taxids)
-    reads1_screed = screed.read_fastq_sequences(reads1)
-    reads2_screed = None
     if reads2:
-        reads2_screed = screed.read_fastq_sequences(reads2)
         if output2 is None:
             raise click.UsageError(f'If paired reads are specified, you must '
                                    f'specify an output file for the filtered '
@@ -129,11 +125,11 @@ def main(reads1: str,
         logging.info(f'Writing n={len(filtered_read_ids)} filtered reads '
                      f'from "{reads1}" to "{output1}"')
 
-        write_reads(reads1_screed, filtered_read_ids, output1)
-        if reads2 and reads2_screed is not None and output2 is not None:
+        write_reads_seqtk(reads1, filtered_read_ids, output1)
+        if reads2 and output2 is not None:
             logging.info(f'Writing n={len(filtered_read_ids)} filtered reads '
                          f'from "{reads2}" to "{output2}"')
-            write_reads(reads2_screed, filtered_read_ids, output2)
+            write_reads_seqtk(reads2, filtered_read_ids, output2)
     logging.info('Done!')
 
 

--- a/filter_classified_reads/util.py
+++ b/filter_classified_reads/util.py
@@ -1,10 +1,13 @@
-import logging
 from typing import List, Optional, Set, TYPE_CHECKING
+import logging
+import re
+import subprocess as sp
 
 import pandas as pd
 
 if TYPE_CHECKING:
-    from filter_classified_reads.target_classified_reads import TargetClassifiedReads # noqa
+    from filter_classified_reads.target_classified_reads import \
+        TargetClassifiedReads  # noqa
 
 
 def prefix_spaces(s: str) -> int:
@@ -26,11 +29,11 @@ def compare_kraken2_and_centrifuge(centrifuge_results: Optional[str],
                                    target_read_ids: Set[str],
                                    tcr: 'TargetClassifiedReads') -> None:
     if centrifuge_results is not None \
-       and kraken2_results is not None \
-       and tcr.kraken2_unclassified is not None \
-       and tcr.kraken2_targets is not None \
-       and tcr.centrifuge_unclassified is not None \
-       and tcr.centrifuge_targets is not None:
+        and kraken2_results is not None \
+        and tcr.kraken2_unclassified is not None \
+        and tcr.kraken2_targets is not None \
+        and tcr.centrifuge_unclassified is not None \
+        and tcr.centrifuge_targets is not None:
         n_target_uq_c = len(tcr.centrifuge_targets - tcr.kraken2_targets)
         n_target_uq_k2 = len(tcr.kraken2_targets - tcr.centrifuge_targets)
         n_target_total = len(target_read_ids)
@@ -43,14 +46,14 @@ def compare_kraken2_and_centrifuge(centrifuge_results: Optional[str],
         uc_uq_k2 = tcr.kraken2_unclassified - tcr.centrifuge_unclassified
         uc_uq_c = tcr.centrifuge_unclassified - tcr.kraken2_unclassified
         if tcr.centrifuge_df_results is not None \
-           and isinstance(tcr.centrifuge_df_results, pd.DataFrame):
+            and isinstance(tcr.centrifuge_df_results, pd.DataFrame):
             c_read_ids = set(tcr.centrifuge_df_results.index)
             n_k2_not_in_centrifuge = len(uc_uq_k2 - c_read_ids)
             if n_k2_not_in_centrifuge:
                 logging.info(f'N={n_k2_not_in_centrifuge} Unclassified reads '
                              f'by Kraken2 not in Centrifuge results')
         if tcr.kraken2_df_results is not None \
-           and isinstance(tcr.kraken2_df_results, pd.DataFrame):
+            and isinstance(tcr.kraken2_df_results, pd.DataFrame):
             k2_read_ids = set(tcr.kraken2_df_results.index)
             n_c_not_in_k2 = len(uc_uq_c - k2_read_ids)
             if n_c_not_in_k2:
@@ -61,3 +64,26 @@ def compare_kraken2_and_centrifuge(centrifuge_results: Optional[str],
                            & tcr.kraken2_unclassified
             logging.info(f'N={len(uc_intersect)} reads unclassified by both '
                          f'Centrifuge and Kraken2.')
+
+def check_bin(bin, version_pattern=None) -> Optional[str]:
+    """Check if a binary app exists else raise a FileNotFoundError"""
+    try:
+        p = sp.Popen([bin], stderr=sp.PIPE)
+        _, stderr = p.communicate()
+        if version_pattern:
+            m = re.search(version_pattern, stderr.decode())
+            if m:
+                return m.group(1)
+            else:
+                raise FileNotFoundError()
+        else:
+            return None
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            'You must have "seqtk" installed to run this program!')
+
+def check_seqtk() -> str:
+    return check_bin('seqtk', r'Version:\s*(\S+)')
+
+def check_pbgzip() -> None:
+    return check_bin('pbgzip')

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,8 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = ['click==7.0',
-                'pandas==0.24.2',
-                'numpy==1.16.2',
-                'screed==1.0',
+                'pandas==0.25.1',
+                'numpy==1.17.2',
                 'attrs>=19.1.0']
 
 setup_requirements = ['pytest-runner', ]
@@ -52,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/filter_classified_reads',
-    version='0.1.0',
+    version='0.2.0',
     zip_safe=False,
 )

--- a/tests/test_filter_classified_reads.py
+++ b/tests/test_filter_classified_reads.py
@@ -25,7 +25,7 @@ c_results = os.path.abspath('tests/data/SRR8207674-centrifuge_results.tsv')
 
 
 def count_lines(path: str) -> int:
-    with open(path) as f:
+    with os.popen(f'zcat < {path}') as f:
         return sum([1 for l in f])
 
 
@@ -90,8 +90,8 @@ def test_command_line_interface():
     assert help_result.exit_code == 0
     assert 'Show this message and exit.' in help_result.output
     with runner.isolated_filesystem():
-        out1 = 'R1.fq'
-        out2 = 'R2.fq'
+        out1 = 'R1.fq.gz'
+        out2 = 'R2.fq.gz'
         test_run = runner.invoke(cli.main, ['-i', r1, '-I', r2,
                                             '-o', out1, '-O', out2,
                                             '-c', c_results, '-C', c_report,

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py37, py36, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
-    3.5: py35
-    3.4: py34
-    2.7: py27
 
 [testenv:flake8]
 basepython = python
@@ -18,6 +16,12 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt
+conda_deps =
+    seqtk
+    pbgzip
+conda_channels =
+    conda-forge
+    bioconda
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
- Added external dependencies for `seqtk` for pulling reads from input FASTQs and `pbgzip` for parallel block Gzip for output of Gzipped FASTQs
- Removed `screed` Python dependency
- Version bump to 0.2.0